### PR TITLE
docs: Add seo, sitemap and robots.txt

### DIFF
--- a/docs/.vuepress/public/robots.txt
+++ b/docs/.vuepress/public/robots.txt
@@ -1,0 +1,19 @@
+# Block OpenAI
+User-agent: GPTBot
+Disallow: /
+User-agent: ChatGPT-User
+Disallow: /
+
+# Block Google Bard AI
+User-agent: Google-Extended
+Disallow: /
+
+# Block Common Crawl
+User-agent: CCBot
+Disallow: /
+
+User-agent: *
+Allow: /
+
+Sitemap: https://seedlingo.com/sitemap.xml
+

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,6 +12,8 @@
         "@vuepress/bundler-vite": "^2.0.0-rc.2",
         "@vuepress/client": "^2.0.0-rc.2",
         "@vuepress/plugin-docsearch": "^2.0.0-rc.3",
+        "@vuepress/plugin-seo": "^2.0.0-rc.5",
+        "@vuepress/plugin-sitemap": "^2.0.0-rc.5",
         "@vuepress/theme-default": "^2.0.0-rc.5",
         "vue": "^3.4.0",
         "vuepress": "^2.0.0-rc.2"

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,6 +25,8 @@
     "@vuepress/bundler-vite": "^2.0.0-rc.2",
     "@vuepress/client": "^2.0.0-rc.2",
     "@vuepress/plugin-docsearch": "^2.0.0-rc.3",
+    "@vuepress/plugin-seo": "^2.0.0-rc.5",
+    "@vuepress/plugin-sitemap": "^2.0.0-rc.5",
     "@vuepress/theme-default": "^2.0.0-rc.5",
     "vue": "^3.4.0",
     "vuepress": "^2.0.0-rc.2"

--- a/docs/vuepress.config.ts
+++ b/docs/vuepress.config.ts
@@ -3,6 +3,8 @@ import { viteBundler } from '@vuepress/bundler-vite';
 import { defaultTheme } from '@vuepress/theme-default';
 import { path } from '@vuepress/utils';
 import docsearch from '@vuepress/plugin-docsearch';
+import { seoPlugin } from '@vuepress/plugin-seo';
+import { sitemapPlugin } from '@vuepress/plugin-sitemap';
 
 export default defineUserConfig({
   bundler: viteBundler(),
@@ -72,5 +74,11 @@ export default defineUserConfig({
         },
       }),
     ],
+    seoPlugin({
+      hostname: 'seedlingo.com',
+    }),
+    sitemapPlugin({
+      hostname: 'seedlingo.com',
+    }),
   ],
 });


### PR DESCRIPTION
Because we'd like Seedlingo.com to be more discoverable

this commit will:
- add a seo plugin that adds open graph and other metadata
- add a sitempat plugin that autogenerates a sitemap
- add a robots.txt file to allow crawlers

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
