### PR TITLE
fix: Inject underscore before build number

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "org.nodepa.seedlingo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 42
-        versionName "1.1.4"
+        versionCode 43
+        versionName "1.1.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seedlingo",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seedlingo",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@ionic/vue": "^7.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlingo",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Modern mobile multi-language literacy - A first-language digital learning tool for adults",
   "homepage": "https://seedlingo.com/get-started",
   "bugs": "https://github.com/nodepa/seedlingo/issues",

--- a/app/src/AppHeader/components/AppHeader.vue
+++ b/app/src/AppHeader/components/AppHeader.vue
@@ -15,7 +15,7 @@ const appVersion = computed(() => {
   } else if (__APP_VERSION__) {
     let v = `v${__APP_VERSION__}`;
     if (__AWS_JOB_ID__) {
-      v += `${__AWS_JOB_ID__}`;
+      v += `_${__AWS_JOB_ID__}`;
     }
     if (__AWS_BRANCH__) {
       v += ` (${__AWS_BRANCH__})`;


### PR DESCRIPTION
Because version number and build number are joined without a space,

this commit will:
- inject an underscore between them

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
