### PR TITLE
fix: Track version and build when not mobile app

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "org.nodepa.seedlingo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 43
-        versionName "1.1.5"
+        versionCode 44
+        versionName "1.1.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seedlingo",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seedlingo",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@ionic/vue": "^7.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlingo",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Modern mobile multi-language literacy - A first-language digital learning tool for adults",
   "homepage": "https://seedlingo.com/get-started",
   "bugs": "https://github.com/nodepa/seedlingo/issues",

--- a/app/src/common/plugins/PlausibleAnalytics.ts
+++ b/app/src/common/plugins/PlausibleAnalytics.ts
@@ -37,14 +37,14 @@ const enableAutoPageviews = async (
     const appInfo = await CapacitorApp.getInfo();
     if (appInfo) {
       props.AppVersion = `v${appInfo.version}_${appInfo.build}`;
-    } else if (__APP_VERSION__) {
-      props.AppVersion = `v${__APP_VERSION__}`;
-      if (__AWS_JOB_ID__) {
-        props.AppVersion += `_${__AWS_JOB_ID__}`;
-      }
-      if (__AWS_BRANCH__) {
-        props.AppVersion += ` (${__AWS_BRANCH__})`;
-      }
+    }
+  } else if (__APP_VERSION__) {
+    props.AppVersion = `v${__APP_VERSION__}`;
+    if (__AWS_JOB_ID__) {
+      props.AppVersion += `_${__AWS_JOB_ID__}`;
+    }
+    if (__AWS_BRANCH__) {
+      props.AppVersion += ` (${__AWS_BRANCH__})`;
     }
   }
   const pageview = () =>


### PR DESCRIPTION
Because an oversight led to the analytics tool not reporting version and build when loading the web app,

this commit will:
- add tracking of version and build number when not in mobile app

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.