### PR TITLE
fix: Constrain pictures to enforce symetrically sized buttons

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "org.nodepa.seedlingo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 47
-        versionName "1.1.8"
+        versionCode 48
+        versionName "1.1.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seedlingo",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seedlingo",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
         "@ionic/vue": "^7.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlingo",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Modern mobile multi-language literacy - A first-language digital learning tool for adults",
   "homepage": "https://seedlingo.com/get-started",
   "bugs": "https://github.com/nodepa/seedlingo/issues",

--- a/app/src/Matching/components/MatchingExercise.vue
+++ b/app/src/Matching/components/MatchingExercise.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, ComputedRef, Ref, ref, watch } from 'vue';
-import { IonCol, IonGrid, IonIcon, IonRow } from '@ionic/vue';
 import { useStore } from 'vuex';
 import ExerciseButton from '../../common/components/ExerciseButton.vue';
 import { MatchingItem } from '../MatchingTypes';
@@ -161,9 +160,7 @@ function checkForMatchAndReOrder(
       }, allOptions.length)
     ) {
       // all options have been matched
-      // setTimeout(() => {
       store.dispatch('setShowContinueButton', true);
-      // }, 500)
     }
   } else {
     // 1 item was selected, now another item is selected
@@ -212,13 +209,19 @@ function getSpacing(itemCount: number, index: number): string {
 <template>
   <ion-grid fixed>
     <ion-row class="ion-justify-content-center">
-      <ion-col v-for="(option, index) in exerciseItems" :key="index" size="6">
+      <ion-col
+        v-for="(option, index) in exerciseItems"
+        :key="index"
+        size="6"
+        :style="`width: 100%; height: calc((100vh - 6.625rem - 0.75rem) / ${exerciseItems.length / 2}); padding: 0.5rem;`"
+      >
         <ExerciseButton
           v-model:buzzing="option.buzzing"
           v-instructions="matchingInstructionsPath"
           :data-test="`option-button-${+index + 1}`"
           :playing="option.audio && option.audio.playing"
           :color="option.color || (option.isWord ? wordColor : nonWordColor)"
+          :style="`width: 100%; height: 100%;`"
           @click="selectAndPlay(option, +index)"
         >
           <template v-if="option.isIcon">
@@ -227,13 +230,15 @@ function getSpacing(itemCount: number, index: number): string {
                 ? option.wordOrIcons
                 : [earOutline]"
               :key="iconIndex"
-              :style="`font-size: 4.0rem;
-              ${getSpacing(option.wordOrIcons.length, +iconIndex)}`"
+              :style="`font-size: 4.0rem; ${getSpacing(option.wordOrIcons.length, +iconIndex)}`"
               :icon="icon"
             />
           </template>
           <template v-else-if="option.picture && option.picture.length > 0">
-            <img :src="option.picture" />
+            <img
+              :src="option.picture"
+              style="width: 100%; height: 100%; object-fit: contain"
+            />
           </template>
           <template v-else>
             <p
@@ -249,21 +254,3 @@ function getSpacing(itemCount: number, index: number): string {
     </ion-row>
   </ion-grid>
 </template>
-
-<style scoped>
-ion-row {
-  height: 100%;
-}
-ion-button {
-  height: 100%;
-  width: 100%;
-  min-height: 4rem;
-  --padding-top: 0.5rem;
-  --padding-bottom: 0.5rem;
-}
-img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-</style>

--- a/app/src/MultipleChoice/components/MultipleChoiceExercise.vue
+++ b/app/src/MultipleChoice/components/MultipleChoiceExercise.vue
@@ -143,7 +143,7 @@ onUpdated(() => {
 
 <template>
   <ion-grid fixed>
-    <ion-row class="top-row ion-justify-content-center" style="height: 30%">
+    <ion-row class="top-row ion-justify-content-center" style="height: 40%">
       <ion-col size="10">
         <ExerciseButton
           ref="itemUnderTestButton"
@@ -206,7 +206,7 @@ onUpdated(() => {
         </ExerciseButton>
       </ion-col>
     </ion-row>
-    <ion-row class="ion-justify-content-around" style="height: 70%">
+    <ion-row class="ion-justify-content-around" style="height: 60%">
       <ion-col
         v-for="(option, index) in exerciseProp.options"
         :key="index"

--- a/app/src/views/ReviewSession.vue
+++ b/app/src/views/ReviewSession.vue
@@ -64,78 +64,76 @@ onMounted(() => {
 
 <template>
   <ion-page>
-    <ion-grid
-      fixed
-      style="
-        height: 100%;
-        padding: 0rem;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-      "
-    >
-      <ion-card
-        style="
-          display: flex;
-          flex: 1;
-          flex-direction: column;
-          justify-content: center;
-          margin: 0rem 0.8rem;
-          max-height: calc(100% - 1.6rem);
-        "
+    <ion-grid fixed style="padding: 0rem">
+      <ion-row
+        class="ion-justify-content-center ion-align-items-center"
+        style="height: 100%"
       >
-        <ion-card-header
-          v-if="word.picture && word.picture.length > 0"
-          style="
-            min-height: 0%;
-            min-width: 0%;
-            display: flex;
-            justify-content: center;
-          "
-        >
-          <img
-            :src="Content.getPicPath(word.picture)"
-            data-test="review-picture"
-            style="object-fit: contain; max-height: 100%"
-          />
-        </ion-card-header>
-        <ion-card-header
-          v-else-if="word.symbol && word.symbol.length > 0"
-          style="display: flex; justify-content: center; align-items: center"
-        >
-          <span>
-            <ion-icon
-              v-for="(icon, iconIndex) in word.symbol"
-              :key="iconIndex"
-              data-test="review-icon"
-              :icon="Content.getIcon(icon)"
-              style="font-size: 4rem"
-            />
-          </span>
-        </ion-card-header>
-        <ion-card-content style="display: flex; flex: 1">
-          <ExerciseButton
-            data-test="review-word"
-            :playing="audio.playing"
-            color="primary"
+        <ion-col size="10">
+          <ion-card
             style="
-              width: 100%;
-              height: auto;
-              min-height: 6rem;
-              font-size: 3rem;
-              --padding-top: 0.5rem;
-              --padding-bottom: 0.5rem;
-              --padding-start: 0.5rem;
-              --padding-end: 0.5rem;
+              display: flex;
+              flex: 1;
+              flex-direction: column;
+              justify-content: center;
+              margin: 0rem;
             "
-            @click="audio.play()"
           >
-            <span style="white-space: break-spaces">
-              {{ word.word }}
-            </span>
-          </ExerciseButton>
-        </ion-card-content>
-      </ion-card>
+            <ion-card-header v-if="word.picture && word.picture.length > 0" >
+              <img
+                data-test="review-picture"
+                :src="Content.getPicPath(word.picture)"
+                style="
+                  max-height: calc(
+                    100vh - 6.625rem - 6rem - 1.25rem - 2.25rem - 1rem
+                  );
+                  object-fit: contain;
+                "
+              />
+            </ion-card-header>
+            <ion-card-header
+              v-else-if="word.symbol && word.symbol.length > 0"
+              style="
+                display: flex;
+                justify-content: center;
+                align-items: center;
+              "
+            >
+              <span>
+                <ion-icon
+                  v-for="(icon, iconIndex) in word.symbol"
+                  :key="iconIndex"
+                  data-test="review-icon"
+                  :icon="Content.getIcon(icon)"
+                  style="font-size: 4rem"
+                />
+              </span>
+            </ion-card-header>
+            <ion-card-content style="display: flex; flex: 1">
+              <ExerciseButton
+                data-test="review-word"
+                :playing="audio.playing"
+                color="primary"
+                style="
+                  width: 100%;
+                  height: auto;
+                  min-height: 6rem;
+                  font-size: 3rem;
+                  --padding-top: 0.5rem;
+                  --padding-bottom: 0.5rem;
+                  --padding-start: 0.5rem;
+                  --padding-end: 0.5rem;
+                "
+                @click="audio.play()"
+              >
+                <span style="white-space: break-spaces">
+                  {{ word.word }}
+                </span>
+              </ExerciseButton>
+            </ion-card-content>
+          </ion-card>
+        </ion-col>
+      </ion-row>
     </ion-grid>
   </ion-page>
 </template>

--- a/content/ContentSpec.json
+++ b/content/ContentSpec.json
@@ -103,7 +103,7 @@
       "lessonSpecFile": "Lesson15.json"
     },
     {
-      "name": "工作，工资,时间",
+      "name": "工作，工资，时间",
       "icon": "mdiAccountHardHat",
       "introductionAudio": "audio/instructions/placeholder-audio.mp3",
       "lessonSpecFile": "Lesson16.json"


### PR DESCRIPTION
Because pictures would fill the width of their button, pictures with aspect ration < 1.5 would become very tall, and the button would expanding and push buttons below off screen.

This commit will:
- constrain the picture within the button by enforcing a fixed height to the button by dividing the available vertical space by the number of button rows

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.