### PR TITLE
docs: Update format version to 1.3.0

### DIFF
--- a/docs/content/content-spec.md
+++ b/docs/content/content-spec.md
@@ -23,7 +23,7 @@ under that name. `ContentSpec.json` describes the file structure of the content.
 Mandatory field of type `string`.
 
 ```json
-"formatVersion": "1.2.1"
+"formatVersion": "1.3.0"
 ```
 
 `formatVersion` is used by the Seedlingo app to determine how the file can be
@@ -113,7 +113,7 @@ corresponding media, i.e. audio, picture, video and/or symbol (i.e. icon).
 Mandatory field of type `string`.
 
 ```json
-"formatVersion": "1.2.1"
+"formatVersion": "1.3.0"
 ```
 
 `formatVersion` is used by the Seedlingo app to determine how the file can be
@@ -178,7 +178,7 @@ which words from the word-specification to include in an exercise.
 Mandatory field of type `string`.
 
 ```json
-"formatVersion": "1.2.1"
+"formatVersion": "1.3.0"
 ```
 
 `formatVersion` is used by the Seedlingo app to determine how the file can be

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "1.1.2",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@vuepress/bundler-vite": "^2.0.0-rc.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "description": "Documentation for Seedlingo.",
   "main": "index.js",
   "author": "toshify <4579559+toshify@users.noreply.github.com>",
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/nodepa/seedlingo#readme",
   "volta": {
-    "node": "18.19.0",
-    "npm": "10.3.0"
+    "node": "20.11.1",
+    "npm": "10.4.0"
   },
   "devDependencies": {
     "@vuepress/bundler-vite": "^2.0.0-rc.2",


### PR DESCRIPTION
Because docs should reflect current app and content format version,

this commit will:
- update docs to reference format version 1.3.0

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.