### PR TITLE
fix: Set project-root relative import refs

### DIFF
--- a/app/src/AppHeader/components/AppHeader.vue
+++ b/app/src/AppHeader/components/AppHeader.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, Ref, ref } from 'vue';
 import { IonHeader, IonImg, IonTitle, IonToolbar } from '@ionic/vue';
-import logoUrl from '../../assets/logo/logo.svg';
+import logoUrl from '@/assets/logo/logo.svg';
 import { App as CapacitorApp } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 

--- a/app/src/BottomNavigationBar/components/ToggleInstructionsButton.vue
+++ b/app/src/BottomNavigationBar/components/ToggleInstructionsButton.vue
@@ -8,9 +8,9 @@ import {
 } from 'vue';
 import { useStore } from 'vuex';
 import { createAnimation, IonButton, IonIcon } from '@ionic/vue';
-import ToggleInstructionsOnIcon from '../../common/icons/ToggleInstructionsOnIcon.svg';
-import ToggleInstructionsOffIcon from '../../common/icons/ToggleInstructionsOffIcon.svg';
-import { Instructions } from '../../common/directives/InstructionsDirective';
+import ToggleInstructionsOnIcon from '@/common/icons/ToggleInstructionsOnIcon.svg';
+import ToggleInstructionsOffIcon from '@/common/icons/ToggleInstructionsOffIcon.svg';
+import { Instructions } from '@/common/directives/InstructionsDirective';
 
 interface Props {
   showInstructionsExplainer?: boolean;

--- a/app/src/Cloze/ClozeTypes.ts
+++ b/app/src/Cloze/ClozeTypes.ts
@@ -1,4 +1,4 @@
-import { ExerciseAudio } from '../common/types/ExerciseAudioType';
+import { ExerciseAudio } from '@/common/types/ExerciseAudioType';
 
 export interface ClozeExercise {
   clozeOptions: Array<ClozeOption>;

--- a/app/src/Cloze/components/ClozeExercise.vue
+++ b/app/src/Cloze/components/ClozeExercise.vue
@@ -2,8 +2,8 @@
 import { computed, ComputedRef, ref, watch } from 'vue';
 import { IonCard, IonCardContent, IonCol, IonGrid, IonRow } from '@ionic/vue';
 import { useStore } from 'vuex';
-import RippleAnimation from '../../common/animations/RippleAnimation.vue';
-import ExerciseButton from '../../common/components/ExerciseButton.vue';
+import RippleAnimation from '@/common/animations/RippleAnimation.vue';
+import ExerciseButton from '@/common/components/ExerciseButton.vue';
 import Content from '@/Content/Content';
 
 import { ClozeExercise, ClozeOption, ClozeWord } from '../ClozeTypes';

--- a/app/src/Cloze/data/SingleClozeTestData.ts
+++ b/app/src/Cloze/data/SingleClozeTestData.ts
@@ -1,8 +1,8 @@
-import 术 from '../../test-support/audio/characters/术.mp3.audio?raw';
-import 两 from '../../test-support/audio/characters/两.mp3.audio?raw';
-import 二 from '../../test-support/audio/characters/二.mp3.audio?raw';
-import 五减二 from '../../test-support/audio/characters/五减二.mp3.audio?raw';
-import placeholderAudio from '../../test-support/audio/placeholder-audio.mp3.audio?raw';
+import 术 from '@/test-support/audio/characters/术.mp3.audio?raw';
+import 两 from '@/test-support/audio/characters/两.mp3.audio?raw';
+import 二 from '@/test-support/audio/characters/二.mp3.audio?raw';
+import 五减二 from '@/test-support/audio/characters/五减二.mp3.audio?raw';
+import placeholderAudio from '@/test-support/audio/placeholder-audio.mp3.audio?raw';
 import { ClozeExercise } from '../ClozeTypes';
 import ExerciseProvider from '@/Content/ExerciseProvider';
 

--- a/app/src/Matching/MatchingTypes.ts
+++ b/app/src/Matching/MatchingTypes.ts
@@ -1,4 +1,4 @@
-import { ExerciseAudio } from '../common/types/ExerciseAudioType';
+import { ExerciseAudio } from '@/common/types/ExerciseAudioType';
 
 export type MatchingExercise = Array<MatchingItem>;
 

--- a/app/src/MultipleChoice/data/ExplanationMultipleChoiceTestData.ts
+++ b/app/src/MultipleChoice/data/ExplanationMultipleChoiceTestData.ts
@@ -1,4 +1,4 @@
-import placeholder from '../../test-support/audio/placeholder-audio.mp3.audio?raw';
+import placeholder from '@/test-support/audio/placeholder-audio.mp3.audio?raw';
 import { MultipleChoiceExercise } from '../MultipleChoiceTypes';
 
 export default function ExplanationMultipleChoiceTestData(): MultipleChoiceExercise {

--- a/app/src/common/components/ExerciseButton.vue
+++ b/app/src/common/components/ExerciseButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ComponentPublicInstance, ref, watch } from 'vue';
 import { IonButton } from '@ionic/vue';
-import RippleAnimation from '../animations/RippleAnimation.vue';
+import RippleAnimation from '@/common/animations/RippleAnimation.vue';
 
 interface Props {
   playing?: boolean;

--- a/app/src/common/components/InstructionsBadge.vue
+++ b/app/src/common/components/InstructionsBadge.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import ToggleInstructionsOnIcon from '../icons/ToggleInstructionsOnIcon.svg?raw';
-import RippleAnimation from '../animations/RippleAnimation.vue';
+import ToggleInstructionsOnIcon from '@/common/icons/ToggleInstructionsOnIcon.svg?raw';
+import RippleAnimation from '@/common/animations/RippleAnimation.vue';
 import { Ref, ref } from 'vue';
 
 interface Props {

--- a/app/src/common/router/index.ts
+++ b/app/src/common/router/index.ts
@@ -1,8 +1,8 @@
 import { createRouter, createWebHistory } from '@ionic/vue-router';
 import { RouteRecordRaw } from 'vue-router';
-import HomeView from '../../views/HomeView.vue';
-import ExerciseSession from '../../views/ExerciseSession.vue';
-import ReviewSession from '../../views/ReviewSession.vue';
+import HomeView from '@/views/HomeView.vue';
+import ExerciseSession from '@/views/ExerciseSession.vue';
+import ReviewSession from '@/views/ReviewSession.vue';
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -21,12 +21,12 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: '/privacy',
     name: 'Privacy policy',
-    component: () => import('../../views/PrivacyPolicy.vue'),
+    component: () => import('@/views/PrivacyPolicy.vue'),
   },
   {
     path: '/about',
     name: 'About',
-    component: () => import('../../views/AboutView.vue'),
+    component: () => import('@/views/AboutView.vue'),
   },
 ];
 

--- a/app/src/common/store/InstructionsModeStore.ts
+++ b/app/src/common/store/InstructionsModeStore.ts
@@ -1,6 +1,6 @@
 import { ActionTree, Module, MutationTree } from 'vuex';
 import { RootState } from './StoreTypes';
-import { InstructionsModeState } from '../directives/InstructionsDirective';
+import { InstructionsModeState } from '@/common/directives/InstructionsDirective';
 
 const getDefaultState = (): InstructionsModeState => {
   return {

--- a/app/src/common/store/StoreTypes.ts
+++ b/app/src/common/store/StoreTypes.ts
@@ -1,4 +1,4 @@
-import { InstructionsModeState } from '../directives/InstructionsDirective';
+import { InstructionsModeState } from '@/common/directives/InstructionsDirective';
 
 export interface RootState {
   version: string;

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -30,14 +30,14 @@ import '@ionic/vue/css/text-alignment.css';
 import '@ionic/vue/css/text-transformation.css';
 import '@ionic/vue/css/flex-utils.css';
 import '@ionic/vue/css/display.css';
-import './common/styles/theme.scss';
+import '@/common/styles/theme.scss';
 
-import Badge from './common/components/InstructionsBadge.vue';
-import InstructionsDirective from './common/directives/InstructionsDirective';
-import App from './App.vue';
-import router from './common/router';
-import store from './common/store/RootStore';
-import { createPlausible } from './common/plugins/PlausibleAnalytics';
+import Badge from '@/common/components/InstructionsBadge.vue';
+import InstructionsDirective from '@/common/directives/InstructionsDirective';
+import App from '@/App.vue';
+import router from '@/common/router';
+import store from '@/common/store/RootStore';
+import { createPlausible } from '@/common/plugins/PlausibleAnalytics';
 
 const app = createApp(App);
 app.use(IonicVue);

--- a/app/src/views/ReviewSession.vue
+++ b/app/src/views/ReviewSession.vue
@@ -11,7 +11,7 @@ import {
   IonPage,
   useIonRouter,
 } from '@ionic/vue';
-import ExerciseButton from '../common/components/ExerciseButton.vue';
+import ExerciseButton from '@/common/components/ExerciseButton.vue';
 import Content from '@/Content/Content';
 import ExerciseProvider from '@/Content/ExerciseProvider';
 // import { earOutline } from 'ionicons/icons';


### PR DESCRIPTION
Because we should only use relative import paths within "modules"

this commit will:
- update some imports to use a project-root relative import path by prefixing "@/" that will be replaced with the project root on build

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.