### PR TITLE
fix: Contain matching exercise within comprehension exercise

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "org.nodepa.seedlingo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 50
-        versionName "1.3.0"
+        versionCode 51
+        versionName "1.3.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seedlingo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seedlingo",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@ionic/vue": "^7.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlingo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Modern mobile multi-language literacy - A first-language digital learning tool for adults",
   "homepage": "https://seedlingo.com/get-started",
   "bugs": "https://github.com/nodepa/seedlingo/issues",

--- a/app/src/Matching/components/MatchingExercise.vue
+++ b/app/src/Matching/components/MatchingExercise.vue
@@ -208,13 +208,13 @@ function getSpacing(itemCount: number, index: number): string {
 </script>
 
 <template>
-  <ion-grid fixed>
-    <ion-row class="ion-justify-content-center">
+  <ion-grid fixed style="max-height: 100%">
+    <ion-row class="ion-justify-content-center" style="height: 100%">
       <ion-col
         v-for="(option, index) in exerciseItems"
         :key="index"
         size="6"
-        :style="`width: 100%; height: calc((100vh - 6.625rem - 0.75rem) / ${exerciseItems.length / 2}); padding: 0.5rem;`"
+        :style="`width: 100%; height: calc(100% / ${exerciseItems.length / 2});  padding: 0.5rem;`"
       >
         <ExerciseButton
           v-model:buzzing="option.buzzing"

--- a/app/src/views/ReviewSession.vue
+++ b/app/src/views/ReviewSession.vue
@@ -79,7 +79,7 @@ onMounted(() => {
               margin: 0rem;
             "
           >
-            <ion-card-header v-if="word.picture && word.picture.length > 0" >
+            <ion-card-header v-if="word.picture && word.picture.length > 0">
               <img
                 data-test="review-picture"
                 :src="Content.getPicPath(word.picture)"


### PR DESCRIPTION
Because we want to keep information on screen
so that users won't have to scroll
(as long as the content can be kept at a legible size regardless)

this commit will:
- change the styling of the matching exercise to ensure it stays contained within its designated area when displayed within a comprehension exercise

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
