### PR TITLE
docs: Fix link on What is Seedlingo-button

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ heroText: Seedlingo
 tagline: Modern mobile multi-language literacy
 actions:
   - text: What is Seedlingo?
-    link: 'index.html#what-is-seedlingo'
+    link: '#what-is-seedlingo'
     type: primary
   - text: Try Seedlingo
     link: 'https://seedlingo.app'


### PR DESCRIPTION
Because an upgrade to tooling broke the What is Seedlingo-button, so that it became unresponsive to clicking,

this commit will:
- change the link address of the button to make it responsive again

**Certification**
- [x] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
