### PR TITLE
test: Improve error reporting on non-unique IDs

### DIFF
--- a/app/tests/unit/UnitValidation.test.ts
+++ b/app/tests/unit/UnitValidation.test.ts
@@ -35,6 +35,7 @@ describe('Integrity of JSON Unit data', () => {
         ids.forEach((id, index, allIds) => {
           if (id === allIds[index - 1]) {
             console.log(`"${id}"`);
+            expect(id).toBe('unique');
           }
         });
       }


### PR DESCRIPTION
Because a content developer should be able to see
which content IDs are identified as not unique
when running the validator,
this commit will:
- add a test that will trigger on non-unique IDs,
  which leads to the system outputting the non-unique IDs

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.