### PR TITLE
feat: Display alphabetic scripts capitalized as specced

### DIFF
--- a/app/src/common/components/ExerciseButton.vue
+++ b/app/src/common/components/ExerciseButton.vue
@@ -74,6 +74,7 @@ function playAnimation(): void {
 <style scoped>
 ion-button {
   margin: 0px;
+  text-transform: none;
 }
 .button-disabled::part(native) {
   color: var(--ion-color-tint);


### PR DESCRIPTION
Because we should support alphabetic scripts,
and display them as specified in the content spec, but Ionic Framework applies upper-casing
to any text presented in a button,
we have to override this behaviour.

This commit will:
- remove the text decoration that Ionic Framework applies to buttons on our custom extended buttons

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
