### PR TITLE
test: Update test depending on translated content

### DIFF
--- a/app/tests/e2e/specs/review.ts
+++ b/app/tests/e2e/specs/review.ts
@@ -44,7 +44,7 @@ describe('马丽 interacts with the "review" system', () => {
     cy.get('[data-test="review-word"]')
       .as('reviewWord')
       .should('be.visible')
-      .contains('一');
+      .contains(/一|one/);
     cy.get(continueButton).should('exist').should('be.visible');
     // 1 word audio played
     cy.get('@audio.play').should('have.callCount', 1);
@@ -88,7 +88,7 @@ describe('马丽 interacts with the "review" system', () => {
     cy.get('[data-test="review-word"]')
       .as('reviewWord')
       .should('be.visible')
-      .contains('二');
+      .contains(/二|two/);
     // 1 word audio played
     cy.get('@audio.play').should('have.callCount', 1);
     cy.get('@audio.play').invoke('resetHistory');


### PR DESCRIPTION
Because content has been translated into English,
but an end-to-end test of the review system
evaluates the presence of the first two words of the first unit, failing the test because those words are now in English.

This commit will update the relevant test
to check for the English translation instead.

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
