### PR TITLE
fix: Amend resize of answer option text

### DIFF
--- a/app/src/Cloze/components/ClozeExercise.vue
+++ b/app/src/Cloze/components/ClozeExercise.vue
@@ -5,6 +5,7 @@ import { useStore } from 'vuex';
 import RippleAnimation from '@/common/animations/RippleAnimation.vue';
 import ExerciseButton from '@/common/components/ExerciseButton.vue';
 import Content from '@/Content/Content';
+import calcFontSize from '@/common/utils/CalcFontSize';
 
 import type { ClozeExercise, ClozeOption, ClozeWord } from '../ClozeTypes';
 
@@ -176,9 +177,11 @@ const clozeInstructionsPath: ComputedRef<string> = computed(() => {
               @click="determineCorrectness(option)"
             >
               <span
-                :style="`font-size: ${
-                  4 - option.word.length * 0.6
-                }rem; margin: 0px; white-space: break-spaces;`"
+                :style="`
+                  font-size: ${calcFontSize(2.5, 1, 10, 'rem', option.word as string, 5)};
+                  margin: 0px;
+                  white-space: break-spaces;
+                `"
               >
                 {{ option.word }}
               </span>

--- a/app/src/Comprehension/components/ComprehensionExercise.vue
+++ b/app/src/Comprehension/components/ComprehensionExercise.vue
@@ -16,6 +16,7 @@ import ProgressBar from './ProgressBar.vue';
 import HoneyBeeInstructor from '@/common/components/HoneyBeeInstructor.vue';
 import MultipleChoiceExercise from '@/MultipleChoice/components/MultipleChoiceExercise.vue';
 import MatchingExercise from '@/Matching/components/MatchingExercise.vue';
+import calcFontSize from '@/common/utils/CalcFontSize';
 
 const store = useStore();
 const ionRouter = useIonRouter();
@@ -340,9 +341,11 @@ function playOptionAudio(option: ComprehensionOption): void {
                   "
                 >
                   <span
-                    :style="`font-size: ${
-                      4 - option.word.length * 0.6
-                    }rem; margin: 0px; white-space: break-spaces;`"
+                    :style="`
+                      font-size: ${calcFontSize(2.5, 1, 10, 'rem', option.word as string, 5)};
+                      margin: 0px;
+                      white-space: break-spaces;
+                    `"
                   >
                     {{ option.word }}
                   </span>

--- a/app/src/Matching/components/MatchingExercise.vue
+++ b/app/src/Matching/components/MatchingExercise.vue
@@ -6,6 +6,7 @@ import { IonCol, IonGrid, IonIcon, IonRow } from '@ionic/vue';
 import ExerciseButton from '@/common/components/ExerciseButton.vue';
 import Content from '@/Content/Content';
 import getSpacing from '../utils/GetSpacing';
+import calcFontSize from '@/common/utils/CalcFontSize';
 import type { MatchingExercise, MatchingItem } from '../MatchingTypes';
 
 const startColors = ['purple', 'pink', 'orange', 'teal'];
@@ -218,7 +219,7 @@ const matchingInstructionsPath: ComputedRef<string> = computed(() => {
           :data-test="`option-button-${+index + 1}`"
           :playing="option.audio && option.audio.playing"
           :color="option.color || (option.isWord ? wordColor : nonWordColor)"
-          :style="`width: 100%; height: 100%;`"
+          style="width: 100%; height: 100%"
           @click="selectAndPlay(option, +index)"
         >
           <template v-if="option.isIcon">
@@ -238,13 +239,15 @@ const matchingInstructionsPath: ComputedRef<string> = computed(() => {
             />
           </template>
           <template v-else>
-            <p
-              :style="`font-size: ${
-                3 - option.wordOrIcons.length * 0.3
-              }rem; margin: 0px; white-space: break-spaces;`"
+            <span
+              :style="`
+                font-size: ${calcFontSize(2.5, 1, 10, 'rem', option.wordOrIcons as string, 5)};
+                margin: 0px;
+                white-space: break-spaces;
+              `"
             >
               {{ option.wordOrIcons }}
-            </p>
+            </span>
           </template>
         </ExerciseButton>
       </ion-col>

--- a/app/src/MultipleChoice/components/MultipleChoiceExercise.vue
+++ b/app/src/MultipleChoice/components/MultipleChoiceExercise.vue
@@ -5,6 +5,7 @@ import { IonCol, IonGrid, IonIcon, IonRow } from '@ionic/vue';
 import { earOutline } from 'ionicons/icons';
 import ExerciseButton from '@/common/components/ExerciseButton.vue';
 import Content from '@/Content/Content';
+import calcFontSize from '@/common/utils/CalcFontSize';
 import type {
   MultipleChoiceExercise,
   MultipleChoiceItem,
@@ -193,9 +194,17 @@ onUpdated(() => {
             "
           >
             <span
-              :style="`font-size: ${
-                2.5 - exerciseProp.explanationToMatch.length * 0.15
-              }rem; white-space: break-spaces;`"
+              :style="{
+                'font-size': calcFontSize(
+                  4,
+                  1,
+                  10,
+                  'rem',
+                  exerciseProp.explanationToMatch,
+                  5,
+                ),
+                'white-space': 'break-spaces',
+              }"
             >
               {{ exerciseProp.explanationToMatch }}
             </span>
@@ -231,9 +240,11 @@ onUpdated(() => {
           @click="determineCorrectness(option)"
         >
           <span
-            :style="`font-size: ${
-              2.5 - option.word.length * 0.15
-            }rem; margin: 0px; white-space: break-spaces;`"
+            :style="{
+              'font-size': calcFontSize(2.5, 1, 10, 'rem', option.word, 5),
+              margin: '0px',
+              'white-space': 'break-spaces',
+            }"
           >
             {{ option.word }}
           </span>

--- a/app/src/common/utils/CalcFontSize.ts
+++ b/app/src/common/utils/CalcFontSize.ts
@@ -1,0 +1,22 @@
+export default function calcFontSize(
+  maxSize: number,
+  minSize: number,
+  steps: number,
+  unit: string,
+  text: string,
+  shrinkThreshold?: number,
+): string {
+  const stepSize = (maxSize - minSize) / steps;
+  const longestWord = text.split(/[- ]/).reduce((currentMax, contender) => {
+    return contender.length > currentMax.length ? contender : currentMax;
+  });
+  if (shrinkThreshold) {
+    if (shrinkThreshold < longestWord.length) {
+      return `clamp(${minSize}${unit}, ${maxSize - (longestWord.length - shrinkThreshold) * stepSize}${unit}, ${maxSize}${unit})`;
+    } else {
+      return maxSize + unit;
+    }
+  } else {
+    return `clamp(${minSize}${unit}, ${maxSize + stepSize - longestWord.length * stepSize}${unit}, ${maxSize}${unit})`;
+  }
+}

--- a/app/src/views/ReviewSession.vue
+++ b/app/src/views/ReviewSession.vue
@@ -114,16 +114,19 @@ onMounted(() => {
                 data-test="review-word"
                 :playing="audio.playing"
                 color="primary"
-                style="
-                  width: 100%;
-                  height: auto;
-                  min-height: 6rem;
-                  font-size: 3rem;
-                  --padding-top: 0.5rem;
-                  --padding-bottom: 0.5rem;
-                  --padding-start: 0.5rem;
-                  --padding-end: 0.5rem;
-                "
+                :style="{
+                  width: '100%',
+                  height: 'auto',
+                  minHeight: '6rem',
+                  'font-size':
+                    'clamp(1rem,' +
+                    (4.15 - word.word.length * 0.15) +
+                    'rem, 4rem)',
+                  '--padding-top': '0.5rem',
+                  '--padding-bottom': '0.5rem',
+                  '--padding-start': '0.5rem',
+                  '--padding-end': '0.5rem',
+                }"
                 @click="audio.play()"
               >
                 <span style="white-space: break-spaces">

--- a/app/tests/e2e/specs/matching.ts
+++ b/app/tests/e2e/specs/matching.ts
@@ -222,7 +222,7 @@ describe('马丽 interacts with the "matching" system', () => {
         cy.get('@option1').should('match', elements[0]);
         cy.get('@option2')
           .should('match', elements[1])
-          .find('p')
+          .find('span')
           .should('have.text', '四');
       });
       // 1 item audio played


### PR DESCRIPTION
When creating content in a language that uses a writing system with an alphabet script rather than a logography,
answer options tend to consist of more symbols.
This surfaces a need to handle scaling of both alpabetic scripts (which tend to form words that are significantly wider than tall, in particular in languages that use inflection or compounding) and logogrphic scrips (which can form words that are taller than wide, i.e. one character words).
Since CSS does not allow us to simply define that a paragraph should fit the container it is placed in,
i.e. scale up to fill the container if the text is one word or scale down to fit within the container if the text is very long, we need sensible parameters for font size to:
- display short text filling at least 50% of its container
- display long text large enough to be legible while not overflowing its container unless it becomes illegible

This commit will:
- amend font-size styles on answer buttons

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
