### PR TITLE
fix: Handle missing explanation audio gracefully

### DIFF
--- a/app/src/Content/ExerciseProvider.ts
+++ b/app/src/Content/ExerciseProvider.ts
@@ -505,9 +505,11 @@ export default class ExerciseProvider {
       } as MatchingItem;
       // wordPart.match = symPart;
 
-      explanationPart.audio = this.createAudio(
-        Content.getAudioData(`${explanationSpec.audio}`),
-      );
+      if (explanationSpec.audio) {
+        explanationPart.audio = this.createAudio(
+          Content.getAudioData(`${explanationSpec.audio}`),
+        );
+      }
 
       wordPart.audio = this.createAudio(
         Content.getAudioData(`${interpretationItem.audio}`),

--- a/app/src/Matching/components/MatchingExercise.vue
+++ b/app/src/Matching/components/MatchingExercise.vue
@@ -48,17 +48,19 @@ function selectAndPlay(option: MatchingItem, index: number): void {
       item.audio.cancel();
     }
   });
-  // handle new selection (see watch(selected, ...)) before playing audio
-  setTimeout(() => {
-    // suppress audio unless unsuppressed, is a word, or has been solved/matched
-    if (
-      exercise.value.unsuppressWordAudio ||
-      !option.isWord ||
-      option.matched
-    ) {
-      option.audio?.play();
-    }
-  }, 0);
+  if (option.audio && option.audio.play) {
+    // handle new selection (see watch(selected, ...)) before playing audio
+    setTimeout(() => {
+      // suppress audio unless unsuppressed, is a word, or has been solved/matched
+      if (
+        exercise.value.unsuppressWordAudio ||
+        !option.isWord ||
+        option.matched
+      ) {
+        option.audio?.play();
+      }
+    }, 0);
+  }
 }
 
 watch(selected, (indexOfSelected: number, indexOfPrevious: number) => {


### PR DESCRIPTION
Because content can be specified
to allow matching and multple choice exercises
with phrases/explanations to match/interpret
without corresponding audio for the phrases/explanations, the app should not expect that audio to exist
and should not attempt to play that audio when it does not exist.

This commit will:
- update the exercise generator to avoid adding audio when it is missing from the content specification
- update the matching exercise presentation to not attempt to play missing audio

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
