### PR TITLE
feat: Add option to present spaces between words

### DIFF
--- a/app/src/Cloze/ClozeTypes.ts
+++ b/app/src/Cloze/ClozeTypes.ts
@@ -4,6 +4,7 @@ export interface ClozeExercise {
   clozeOptions: Array<ClozeOption>;
   clozeText: Array<ClozeWord>;
   clozeType: 'SingleCloze' | 'MultiCloze';
+  injectSpaces?: boolean;
 }
 
 export interface ClozeWord {

--- a/app/src/Cloze/components/ClozeExercise.vue
+++ b/app/src/Cloze/components/ClozeExercise.vue
@@ -113,50 +113,49 @@ const clozeInstructionsPath: ComputedRef<string> = computed(() => {
               v-for="(word, index) in exercise.clozeText"
               :key="`start-${index}`"
             >
-              <span class="no-wrap">
-                <span
-                  :data-test="`sentence-word-${index + 1}`"
-                  style="padding-top: 2px"
-                  :class="[
-                    'selectable',
-                    'ripple-container',
-                    { revealed: word.isBlank && word.revealed },
-                    { interactive: !word.isBlank || word.revealed },
-                    { playing: word.audio?.playing },
-                  ]"
-                  @click="
-                    if (
-                      !word.suppressClozeAudio &&
-                      (!word.isBlank || word.revealed)
-                    )
-                      word.audio?.play();
-                  "
-                >
+              <template v-if="!word.isPunctuation">
+                <span class="no-wrap">
                   <span
-                    v-if="word.isBlank && !word.revealed"
-                    class="cloze-blank"
-                    >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
-                  >
-                  <template
-                    v-else-if="
-                      !word.isPunctuation && (!word.isBlank || word.revealed)
+                    :data-test="`sentence-word-${index + 1}`"
+                    style="padding-top: 2px"
+                    :class="[
+                      'selectable',
+                      'ripple-container',
+                      { revealed: word.isBlank && word.revealed },
+                      { interactive: !word.isBlank || word.revealed },
+                      { playing: word.audio?.playing },
+                    ]"
+                    @click="
+                      if (
+                        !word.suppressClozeAudio &&
+                        (!word.isBlank || word.revealed)
+                      )
+                        word.audio?.play();
                     "
                   >
-                    {{ word.word }}
-                  </template>
-                  <RippleAnimation :playing="word.audio?.playing" />
+                    <span
+                      v-if="word.isBlank && !word.revealed"
+                      class="cloze-blank"
+                      >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
+                    >
+                    <span v-else-if="!word.isBlank || word.revealed">
+                      {{ word.word }}
+                    </span>
+                    <RippleAnimation :playing="word.audio?.playing" />
+                  </span>
+                  <span
+                    v-if="
+                      exercise.clozeText[index + 1] &&
+                      exercise.clozeText[index + 1].isPunctuation
+                    "
+                    :data-test="`sentence-word-${index + 1}-punctuation`"
+                    class="selectable punctuation"
+                    >{{ exercise.clozeText[index + 1].word }}
+                  </span>
                 </span>
-                <span
-                  v-if="
-                    exercise.clozeText[index + 1] &&
-                    exercise.clozeText[index + 1].isPunctuation
-                  "
-                  :data-test="`sentence-word-${index + 1}-punctuation`"
-                  class="selectable punctuation"
-                  >{{ exercise.clozeText[index + 1].word }}
-                </span>
-              </span>
-              <wbr />
+                {{ exercise.injectSpaces ? ' ' : '' }}
+                <wbr />
+              </template>
             </template>
           </ion-card-content>
         </ion-card>

--- a/app/src/Comprehension/ComprehensionTypes.ts
+++ b/app/src/Comprehension/ComprehensionTypes.ts
@@ -7,6 +7,7 @@ export interface ComprehensionExercise {
   questions: Array<ComprehensionQuestion>;
   stages: Array<ComprehensionStage>;
   newWordsExercises?: Array<MultipleChoiceExercise | MatchingExercise>;
+  injectSpaces?: boolean;
 }
 
 export interface ComprehensionWord {

--- a/app/src/Comprehension/components/ComprehensionExercise.vue
+++ b/app/src/Comprehension/components/ComprehensionExercise.vue
@@ -247,49 +247,52 @@ function playOptionAudio(option: ComprehensionOption): void {
                 v-for="(word, index) in exercise.comprehensionText"
                 :key="`start-${index}`"
               >
-                <span class="no-wrap">
-                  <span
-                    :data-test="`sentence-word-${index + 1}`"
-                    :class="[
-                      'selectable',
-                      'ripple-container',
-                      {
-                        interactive:
+                <template v-if="!word.isPunctuation">
+                  <span class="no-wrap">
+                    <span
+                      :data-test="`sentence-word-${index + 1}`"
+                      :class="[
+                        'selectable',
+                        'ripple-container',
+                        {
+                          interactive:
+                            allowWordInteraction &&
+                            !word.suppressComprehensionAudio,
+                        },
+                        { playing: word.audio?.playing },
+                      ]"
+                      style="padding-top: 2px"
+                      :style="`${
+                        currentStage >= STAGE.FocusNewWords && word.isNew
+                          ? 'color: var(--ion-color-tertiary);'
+                          : ''
+                      }`"
+                      @click="
+                        if (
                           allowWordInteraction &&
-                          !word.suppressComprehensionAudio,
-                      },
-                      { playing: word.audio?.playing },
-                    ]"
-                    style="padding-top: 2px"
-                    :style="`${
-                      currentStage >= STAGE.FocusNewWords && word.isNew
-                        ? 'color: var(--ion-color-tertiary);'
-                        : ''
-                    }`"
-                    @click="
-                      if (
-                        allowWordInteraction &&
-                        !word.suppressComprehensionAudio
-                      )
-                        word.audio?.play();
-                    "
-                  >
-                    <template v-if="!word.isPunctuation">
-                      {{ word.word }}
-                    </template>
-                    <RippleAnimation :playing="word.audio?.playing" />
+                          !word.suppressComprehensionAudio
+                        )
+                          word.audio?.play();
+                      "
+                    >
+                      <span>
+                        {{ word.word }}
+                      </span>
+                      <RippleAnimation :playing="word.audio?.playing" />
+                    </span>
+                    <span
+                      v-if="
+                        exercise.comprehensionText[index + 1] &&
+                        exercise.comprehensionText[index + 1].isPunctuation
+                      "
+                      :data-test="`sentence-word-${index + 1}-punctuation`"
+                      class="selectable punctuation"
+                      >{{ exercise.comprehensionText[index + 1].word }}
+                    </span>
                   </span>
-                  <span
-                    v-if="
-                      exercise.comprehensionText[index + 1] &&
-                      exercise.comprehensionText[index + 1].isPunctuation
-                    "
-                    :data-test="`sentence-word-${index + 1}-punctuation`"
-                    class="selectable punctuation"
-                    >{{ exercise.comprehensionText[index + 1].word }}
-                  </span></span
-                >
-                <wbr />
+                  {{ exercise.injectSpaces ? ' ' : '' }}
+                  <wbr />
+                </template>
               </template>
             </ion-card-content>
           </ion-card>

--- a/app/src/Content/ExerciseProvider.ts
+++ b/app/src/Content/ExerciseProvider.ts
@@ -204,7 +204,7 @@ export default class ExerciseProvider {
     const multipleChoiceExercise = {
       explanationToMatch: explanationSpec.explanation
         .map((wordRef) => Content.getWord(wordRef).word)
-        .join(''),
+        .join(explanationSpec.injectSpaces ? ' ' : ''),
       options: [] as Array<MultipleChoiceItem>,
     } as MultipleChoiceExercise;
 
@@ -469,7 +469,7 @@ export default class ExerciseProvider {
       const explanationPart = {
         wordOrIcons: explanationSpec.explanation
           ?.map((wordRef) => Content.getWord(wordRef).word)
-          .join(''),
+          .join(explanationSpec.injectSpaces ? ' ' : ''),
         audio: {} as ExerciseAudio,
         // match: {} as MatchingItem
         match: index * 2 + 1,
@@ -766,6 +766,7 @@ export default class ExerciseProvider {
       clozeType: 'SingleCloze',
       clozeText,
       clozeOptions,
+      injectSpaces: true,
     } as ClozeExercise;
   }
 
@@ -912,6 +913,7 @@ export default class ExerciseProvider {
     }
 
     const comprehensionExercise = {} as ComprehensionExercise;
+    comprehensionExercise.injectSpaces = true;
 
     comprehensionExercise.stages = comprehensionSpec.comprehensionStages?.map(
       (stageSpec) => {

--- a/app/src/common/types/ContentTypes.ts
+++ b/app/src/common/types/ContentTypes.ts
@@ -99,6 +99,7 @@ export interface ExplanationSpec {
     invalidOptions: Array<WordRef>;
   };
   audio?: string;
+  injectSpaces?: boolean;
 }
 
 export interface ClozeSpec {

--- a/app/tests/e2e/specs/cloze.ts
+++ b/app/tests/e2e/specs/cloze.ts
@@ -68,7 +68,7 @@ describe('马丽 interacts with the "cloze" system', () => {
         .contains('五减二');
       cy.get(sentenceCard)
         .should('be.visible')
-        .contains('我有 个弟弟，不过没有别的兄弟姐妹。');
+        .contains('我 有 个 弟弟， 不过 没有 别的 兄弟姐妹。');
       cy.get(continueButton).should('not.exist');
 
       // *****
@@ -104,7 +104,9 @@ describe('马丽 interacts with the "cloze" system', () => {
         .click()
         .should('have.class', 'ion-color-success')
         .should('not.have.class', 'button-disabled');
-      cy.get(sentenceCard).contains('我有两个弟弟，不过没有别的兄弟姐妹。');
+      cy.get(sentenceCard).contains(
+        '我 有 两 个 弟弟， 不过 没有 别的 兄弟姐妹。',
+      );
       cy.get(sentenceBlank).should(
         'have.css',
         'background-color',
@@ -184,7 +186,7 @@ describe('马丽 interacts with the "cloze" system', () => {
         .contains('有');
       cy.get(sentenceCard)
         .should('be.visible')
-        .contains('我 个弟弟，不过 别的 。');
+        .contains('我 个 弟弟， 不过 别的 。');
       cy.get(continueButton).should('not.exist');
 
       // *****
@@ -249,6 +251,7 @@ describe('马丽 interacts with the "cloze" system', () => {
       cy.log("-- hears the word's audio");
       cy.get('@option4').click().should('have.class', 'button-disabled');
       cy.get('[data-test="sentence-word-2"]')
+        .as('word2')
         .should('have.css', 'background-color', transparentBackground)
         .contains('有');
 
@@ -274,9 +277,10 @@ describe('马丽 interacts with the "cloze" system', () => {
 
       // non-blank word
       cy.get('[data-test="sentence-word-1"]')
+        .as('word1')
         .should('have.css', 'background-color', transparentBackground)
         .contains('我');
-      cy.get('[data-test="sentence-word-1"]').click();
+      cy.get('@word1').click();
       // 1 audio played
       cy.get('@audio.play').should('have.callCount', 1);
       cy.get('@audio.play').invoke('resetHistory');
@@ -288,10 +292,10 @@ describe('马丽 interacts with the "cloze" system', () => {
       cy.get('@animation.animate').invoke('resetHistory');
 
       // revealed blank-word
-      cy.get('[data-test="sentence-word-2"]')
+      cy.get('@word2')
         .should('have.css', 'background-color', transparentBackground)
-        .contains('有')
-        .click();
+        .contains('有');
+      cy.get('@word2').click();
       // 1 audio played
       cy.get('@audio.play').should('have.callCount', 1);
       cy.get('@audio.play').invoke('resetHistory');


### PR DESCRIPTION
Because the app was initially developed for Simplified Chinese, we chose to not present spaces between words.
We will now introduce support for alphabetic scripts.

This commit will:
- add optional content spec flags for exercise text where spaces should be added
- add spaces when presenting explanations, cloze texts and comprehension texts if the space-injection flags have been set

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
