### PR TITLE
feat: Improve text aligning for alphabet scripts

### DIFF
--- a/app/src/Cloze/components/ClozeExercise.vue
+++ b/app/src/Cloze/components/ClozeExercise.vue
@@ -108,7 +108,7 @@ const clozeInstructionsPath: ComputedRef<string> = computed(() => {
           data-test="sentence-card"
           color="card"
         >
-          <ion-card-content class="ion-text-justify">
+          <ion-card-content class="ion-text-start">
             <template
               v-for="(word, index) in exercise.clozeText"
               :key="`start-${index}`"

--- a/app/src/Comprehension/components/ComprehensionExercise.vue
+++ b/app/src/Comprehension/components/ComprehensionExercise.vue
@@ -231,7 +231,7 @@ function playOptionAudio(option: ComprehensionOption): void {
           <!-- Unit text -->
           <ion-card data-test="sentence-card" color="card" background="primary">
             <ion-card-content
-              class="ion-text-justify"
+              class="ion-text-start"
               :style="`
               font-size: ${
                 [STAGE.ReadText, STAGE.FocusNewWords, STAGE.Review].includes(

--- a/app/src/UnitsMenu/components/UnitsMenu.vue
+++ b/app/src/UnitsMenu/components/UnitsMenu.vue
@@ -26,7 +26,7 @@ const weightLifter = Content.getIcon('mdiWeightLifter');
       :key="index"
       :data-test="`unit-${String(index).padStart(2, '0')}`"
     >
-      <ion-card class="margin-auto">
+      <ion-card class="margin-auto" style="width: 18rem">
         <ion-card-header>
           <ion-card-title
             class="center-content align-vertical"
@@ -77,6 +77,7 @@ const weightLifter = Content.getIcon('mdiWeightLifter');
 .center-content {
   display: flex;
   justify-content: center;
+  text-align: center;
 }
 .align-vertical {
   align-items: center;


### PR DESCRIPTION
Because we are adding content using alphabet scripts, and justified text tend to be harder to read,

this commit will:
- change text aligning to left for left-to-right and right for right-to-left languages (i.e. text-align: start)
- improve presenetation of the units menu to properly center text

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
