### PR TITLE
fix: Remove erroneously added non-specced spaces

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seedlingo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seedlingo",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@ionic/vue": "^8.2.6",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlingo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Modern mobile multi-language literacy - A first-language digital learning tool for adults",
   "homepage": "https://seedlingo.com/get-started",
   "bugs": "https://github.com/nodepa/seedlingo/issues",

--- a/app/src/Cloze/components/ClozeExercise.vue
+++ b/app/src/Cloze/components/ClozeExercise.vue
@@ -153,7 +153,7 @@ const clozeInstructionsPath: ComputedRef<string> = computed(() => {
                     >{{ exercise.clozeText[index + 1].word }}
                   </span>
                 </span>
-                {{ exercise.injectSpaces ? ' ' : '' }}
+                <span v-if="exercise.injectSpaces">{{ ' ' }}</span>
                 <wbr />
               </template>
             </template>

--- a/app/src/Comprehension/components/ComprehensionExercise.vue
+++ b/app/src/Comprehension/components/ComprehensionExercise.vue
@@ -290,7 +290,7 @@ function playOptionAudio(option: ComprehensionOption): void {
                       >{{ exercise.comprehensionText[index + 1].word }}
                     </span>
                   </span>
-                  {{ exercise.injectSpaces ? ' ' : '' }}
+                  <span v-if="exercise.injectSpaces">{{ ' ' }}</span>
                   <wbr />
                 </template>
               </template>

--- a/app/src/common/types/ContentTypes.ts
+++ b/app/src/common/types/ContentTypes.ts
@@ -106,6 +106,7 @@ export interface ClozeSpec {
   text?: Array<WordRef | Blank>;
   suppressClozeAudio?: boolean;
   suppressOptionAudio?: boolean;
+  injectSpaces?: boolean;
 }
 
 export interface ComprehensionSpec {
@@ -115,6 +116,7 @@ export interface ComprehensionSpec {
   suppressOptionAudio?: boolean;
   comprehensionQuestions?: Array<ComprehensionQuestionSpec>;
   comprehensionStages?: Array<ComprehensionStageSpec>;
+  injectSpaces?: boolean;
 }
 export interface ComprehensionQuestionSpec {
   questionText: string;

--- a/app/tests/e2e/specs/cloze.ts
+++ b/app/tests/e2e/specs/cloze.ts
@@ -68,7 +68,7 @@ describe('马丽 interacts with the "cloze" system', () => {
         .contains('五减二');
       cy.get(sentenceCard)
         .should('be.visible')
-        .contains('我 有 个 弟弟， 不过 没有 别的 兄弟姐妹。');
+        .contains('我有 个弟弟，不过没有别的兄弟姐妹。');
       cy.get(continueButton).should('not.exist');
 
       // *****
@@ -105,7 +105,7 @@ describe('马丽 interacts with the "cloze" system', () => {
         .should('have.class', 'ion-color-success')
         .should('not.have.class', 'button-disabled');
       cy.get(sentenceCard).contains(
-        '我 有 两 个 弟弟， 不过 没有 别的 兄弟姐妹。',
+        '我有两个弟弟，不过没有别的兄弟姐妹。',
       );
       cy.get(sentenceBlank).should(
         'have.css',
@@ -186,7 +186,7 @@ describe('马丽 interacts with the "cloze" system', () => {
         .contains('有');
       cy.get(sentenceCard)
         .should('be.visible')
-        .contains('我 个 弟弟， 不过 别的 。');
+        .contains('我 个弟弟，不过 别的 。');
       cy.get(continueButton).should('not.exist');
 
       // *****


### PR DESCRIPTION
Because we add spaces to cloze and comprehension exercises without checking the relevant flags in the spec,
we always add spaces between words indiscriminately. The presentation of text should instead add spaces only when specified.

This commit will:
- update the exercise generator to actually pass the inject spaces-flag on to the renderer
- update the renderer to more robustly present spaces

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.
