### PR TITLE
fix: Prevent hiding of instructor text behind options

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "org.nodepa.seedlingo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 77
-        versionName "1.5.5"
+        versionCode 78
+        versionName "1.5.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seedlingo",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seedlingo",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "license": "MIT",
       "dependencies": {
         "@ionic/vue": "^8.3.2",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlingo",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Modern mobile multi-language literacy - A first-language digital learning tool for adults",
   "homepage": "https://seedlingo.com/get-started",
   "bugs": "https://github.com/nodepa/seedlingo/issues",
@@ -24,8 +24,10 @@
   },
   "scripts": {
     "ba": "npm run build:android",
+    "bas": "npm run build:android:sign-only",
     "build": "npm install && npm run lint:tsc && vite build",
     "build:android": "npm run build && cap telemetry off && cap sync && node versionsync.mjs && cd android && yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses && ./gradlew assembleRelease && cd app/build/outputs/apk/release && for filename in *.unsigned.apk ; do $ANDROID_HOME/build-tools/34.0.0/zipalign 4 $filename ${filename%unsigned*}unsigned.aligned${filename##*unsigned} && $ANDROID_HOME/build-tools/34.0.0/apksigner sign -v --ks ~/.android/apksign.keystore --out ${filename%.unsigned*}${filename##*unsigned} ${filename%unsigned*}unsigned.aligned${filename##*unsigned} ; done",
+    "build:android:sign-only": "cd android/app/build/outputs/apk/release && for filename in *.unsigned.aligned.apk ; do $ANDROID_HOME/build-tools/34.0.0/apksigner sign -v --ks ~/.android/apksign.keystore --out ${filename%.unsigned*}${filename##*unsigned.aligned} ${filename%unsigned*}unsigned${filename##*unsigned} ; done",
     "build:android:debug": "npm run build && cap telemetry off && cap sync && node versionsync.mjs && cd android && yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses && ./gradlew assembleDebug && cd app/build/outputs/apk/debug && for filename in *.unsigned.apk ; do $ANDROID_HOME/build-tools/34.0.0/zipalign 4 $filename ${filename%unsigned*}unsigned.aligned${filename##*unsigned} && $ANDROID_HOME/build-tools/34.0.0/apksigner sign -v --ks ~/.android/apksign.keystore --out ${filename%.unsigned*}${filename##*unsigned} ${filename%unsigned*}unsigned.aligned${filename##*unsigned} ; done",
     "dev": "vite",
     "genass": "cd public && pwd && npx pwa-asset-generator --background 'linear-gradient(#19D2FE, #1E64F0)' --padding '0px' --favicon --single-quotes --type png ../src/assets/logo/logo.svg ./logo",

--- a/app/src/Comprehension/components/ComprehensionExercise.vue
+++ b/app/src/Comprehension/components/ComprehensionExercise.vue
@@ -226,7 +226,7 @@ function playOptionAudio(option: ComprehensionOption): void {
             :text="exercise.stages[currentStage].instructionText"
             :centered="exercise.stages[currentStage].instructionAudio?.playing"
             :style="{
-              transition: '1s ease-in-out',
+              margin: '0px',
               marginInline: '10px',
               marginBottom: exercise.stages[currentStage].instructionAudio
                 ?.playing
@@ -247,7 +247,6 @@ function playOptionAudio(option: ComprehensionOption): void {
                   ? '1.8rem'
                   : '1.2rem'
               };
-              transition: 1s ease-in-out;
             `"
             >
               <template

--- a/app/src/common/components/HoneyBeeInstructor.vue
+++ b/app/src/common/components/HoneyBeeInstructor.vue
@@ -24,14 +24,14 @@ type IonCardType = InstanceType<typeof IonCard>;
 const card = useTemplateRef<IonCardType>('honeybee-card');
 const cardHeight = computed(() => {
   if (card.value?.$el) {
-    return +getComputedStyle(card.value.$el).height.replace('px', '');
+    return getComputedStyle(card.value.$el).height;
   } else {
-    return 0;
+    return '0px';
   }
 });
 </script>
 <template>
-  <div>
+  <div style="position: relative; transition: 1s ease-in-out">
     <!-- Honeybee icon -->
     <button
       :style="{
@@ -67,14 +67,9 @@ const cardHeight = computed(() => {
     <div
       :style="{
         width: '100%',
-        height: audio?.playing ? `${cardHeight}px` : '0px',
-        marginTop: '-20px',
-        scale: audio?.playing ? 1 : 0,
-        translate: centered
-          ? undefined
-          : audio?.playing
-            ? '0% 0%'
-            : 'calc(-50% - 10px) calc(-50% - 10px)',
+        height: audio?.playing ? cardHeight : '0px',
+        transformOrigin: centered ? 'center' : 'left top 0px',
+        transform: `scale(${audio?.playing ? 1 : 0})`,
         transition: '1s ease-in-out',
       }"
     >


### PR DESCRIPTION
Because the instructor text sometimes gets covered by the answer options in comprehension exercises,

this commit will:
- ensure that the text has enough room and scales correctly

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.