### PR TITLE
fix: Configure vite to use modern sass compiler

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "org.nodepa.seedlingo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 78
-        versionName "1.5.6"
+        versionCode 79
+        versionName "1.5.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seedlingo",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seedlingo",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "license": "MIT",
       "dependencies": {
         "@ionic/vue": "^8.3.2",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlingo",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Modern mobile multi-language literacy - A first-language digital learning tool for adults",
   "homepage": "https://seedlingo.com/get-started",
   "bugs": "https://github.com/nodepa/seedlingo/issues",

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -75,4 +75,11 @@ export default defineConfig({
       },
     },
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler',
+      },
+    },
+  },
 });


### PR DESCRIPTION
Because the legacy api of Dart Sass is deprecated,

this commit will:
- configure Vite to use the modern compiler api instead

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.